### PR TITLE
Run one job at a time

### DIFF
--- a/lib/ci_in_a_can/build.rb
+++ b/lib/ci_in_a_can/build.rb
@@ -14,6 +14,13 @@ module CiInACan
       GithubBuildParser.new.parse content
     end
 
+    def self.create_for file, working_location
+      build = CiInACan::Build.parse File.read(file)
+      build.id = UUID.new.generate
+      build.local_location = "#{working_location}/#{build.id}"
+      build
+    end
+
     def commands
       commands = CiInACan::Repo.find(repo).build_commands
       commands.count > 0 ? commands : ['bundle install', 'bundle exec rake']

--- a/lib/ci_in_a_can/runner.rb
+++ b/lib/ci_in_a_can/runner.rb
@@ -2,6 +2,12 @@ module CiInACan
 
   module Runner
 
+    def self.process_job_file file, working_location
+      build = Build.create_for file, working_location
+      delete file
+      Runner.run build
+    end
+
     def self.run build
       report_pending_status_for build
       clone_a_local_copy_of build
@@ -11,6 +17,11 @@ module CiInACan
     end
 
     private
+
+    def self.delete file
+      File.delete file
+    rescue
+    end
 
     def self.send_notifications_for build, test_results
       CiInACan::TestResultNotifier.send_for build, test_results

--- a/lib/ci_in_a_can/watcher.rb
+++ b/lib/ci_in_a_can/watcher.rb
@@ -21,7 +21,7 @@ module CiInACan
         Proc.new do |_, new_files, _|
           next unless new_files.count > 0
 
-          build = create_a_build_for(new_files.first, working_location)
+          build = Build.create_for new_files.first, working_location
 
           delete new_files.first
 
@@ -36,10 +36,6 @@ module CiInACan
       end
 
       def create_a_build_for file, working_location
-        build = CiInACan::Build.parse File.read(file)
-        build.id = UUID.new.generate
-        build.local_location = "#{working_location}/#{build.id}"
-        build
       end
 
     end

--- a/lib/ci_in_a_can/watcher.rb
+++ b/lib/ci_in_a_can/watcher.rb
@@ -20,13 +20,7 @@ module CiInACan
       def build_callback working_location
         Proc.new do |_, new_files, _|
           next unless new_files.count > 0
-
-          build = Build.create_for new_files.first, working_location
-
-          delete new_files.first
-
-          Runner.run build
-
+          Runner.process_job_file new_files.first, working_location
         end
       end
 

--- a/lib/ci_in_a_can/watcher.rb
+++ b/lib/ci_in_a_can/watcher.rb
@@ -19,8 +19,8 @@ module CiInACan
 
       def build_callback working_location
         Proc.new do |_, new_files, _|
-          next unless new_files.count > 0
-          Runner.process_job_file new_files.first, working_location
+          next if new_files.count == 0
+          CiInACan::Runner.wake_up
         end
       end
 

--- a/lib/ci_in_a_can/watcher.rb
+++ b/lib/ci_in_a_can/watcher.rb
@@ -24,14 +24,6 @@ module CiInACan
         end
       end
 
-      def delete file
-        File.delete file
-      rescue
-      end
-
-      def create_a_build_for file, working_location
-      end
-
     end
 
   end

--- a/spec/ci_in_a_can/build_spec.rb
+++ b/spec/ci_in_a_can/build_spec.rb
@@ -18,6 +18,67 @@ describe CiInACan::Build do
     build.created_at.must_be_same_as now
   end
 
+  describe "creating for a file" do
+
+    let(:file)             { Object.new }
+    let(:file_contents)    { Object.new }
+    let(:working_location) { "a" }
+
+    before do
+      File.stubs(:read).with(file).returns file_contents
+      CiInACan::Build.stubs(:parse).returns CiInACan::Build.new
+    end
+
+    it "should return a build parsed from the file contents" do
+
+      expected_build = CiInACan::Build.new
+
+      CiInACan::Build.stubs(:parse)
+                     .with(file_contents)
+                     .returns expected_build
+
+      build = CiInACan::Build.create_for file, working_location
+
+      build.must_be_same_as expected_build
+        
+    end
+
+    [
+      ['a', '1234'],
+      ['b', '5678'],
+    ].map { |x| Struct.new(:working_location, :unique_identifier).new(*x) }.each do |example|
+
+      describe "details" do
+
+        let(:working_location) { example.working_location }
+
+        it "should set the id to a new UUID" do
+          uuid = Object.new
+          UUID.stubs(:new).returns uuid
+          uuid.stubs(:generate).returns example.unique_identifier
+
+          build = CiInACan::Build.create_for file, working_location
+
+          build.id.must_equal example.unique_identifier
+            
+        end
+
+        it "should set the local location" do
+          uuid = Object.new
+          UUID.stubs(:new).returns uuid
+          uuid.stubs(:generate).returns example.unique_identifier
+
+          build = CiInACan::Build.create_for file, working_location
+
+          build.local_location.must_equal "#{example.working_location}/#{example.unique_identifier}"
+        end
+
+      end
+
+    end
+
+  end
+
   describe "commands" do
 
     let(:repo_name) { Object.new }

--- a/spec/ci_in_a_can/runner_spec.rb
+++ b/spec/ci_in_a_can/runner_spec.rb
@@ -65,4 +65,35 @@ describe CiInACan::Runner do
 
   end
 
+  describe "process job file" do
+
+    let(:file)             { Object.new }
+    let(:working_location) { Object.new }
+    let(:build)            { Object.new }
+
+    before do
+      CiInACan::Build.stubs(:create_for).returns build
+      CiInACan::Runner.stubs(:run).with build
+    end
+
+    it "should create a build for the file and run it" do
+      CiInACan::Build.stubs(:create_for).with(file, working_location).returns build
+      CiInACan::Runner.expects(:run).with build
+      CiInACan::Runner.process_job_file file, working_location
+    end
+
+    it "should delete the file" do
+      File.expects(:delete).with file
+      CiInACan::Runner.process_job_file file, working_location
+    end
+
+    it "should delete the file after the build has been created" do
+      File.expects(:delete).with do |file|
+        CiInACan::Build.stubs(:create_for).raises 'deleted too early'
+        true
+      end
+      CiInACan::Runner.process_job_file file, working_location
+    end
+  end
+
 end

--- a/spec/ci_in_a_can/runner_spec.rb
+++ b/spec/ci_in_a_can/runner_spec.rb
@@ -2,6 +2,12 @@ require_relative '../spec_helper'
 
 describe CiInACan::Runner do
 
+  describe "wake up" do
+    it "should this should fire off a separate process that will read one file from the jobs folder" do
+      raise 'this does not exist yet.'
+    end
+  end
+
   describe "run" do
 
     let(:build)  { CiInACan::Build.new }


### PR DESCRIPTION
Instead of watching and running the job in one swipe, break off a separate process to run a single file.  Then repeat.
